### PR TITLE
improve json compatibility

### DIFF
--- a/json.bro
+++ b/json.bro
@@ -29,6 +29,9 @@ function convert(v: any, only_loggable: bool &default=F): string
 		fallthrough;
 		case "port":
 		return cat("\"", v, "\"");
+		case "bool":
+		local b: bool = v;
+		return b ? "true" : "false";
 
 		case "int":
 		fallthrough;
@@ -38,10 +41,8 @@ function convert(v: any, only_loggable: bool &default=F): string
 		fallthrough;
 		case "double":
 		fallthrough;
-		case "bool":
-		fallthrough;
 		case "enum":
-		return cat(v);
+		return cat("\"", v, "\"");
 
 		default:
 		break;


### PR DESCRIPTION
This improves compatibility so that one can do:

```
# t.bro
@load ./json

event connection_state_remove(c: connection) {
    print JSON::convert(c);
}
```

And run

```
bro -r exercise_traffic.pcap t.bro  | jq .
```

And not get any errors
